### PR TITLE
chore: Treeshake Docs add 'MathUtils'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ const subsetOfTHREE = {
 	Box3      : Box3,
 	Sphere    : Sphere,
 	Raycaster : Raycaster,
+	MathUtils : MathUtils
 };
 
 CameraControls.install( { THREE: subsetOfTHREE } );


### PR DESCRIPTION
Scroll/zoom uses Mathutils.clamp